### PR TITLE
Mrb console testing

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -5,6 +5,14 @@ exports.handler = function(event, context) {
     context.done(result);
   });
 
-  child.stdout.on('data', console.log);
-  child.stderr.on('data', console.error);
+  child.stdout.on('data', function (data) {
+    data.split("\n").forEach(function(x) {
+      console.log(x);
+    });
+  });
+  child.stderr.on('data', function (data) {
+    data.split("\n").forEach(function(x) {
+      console.log(x);
+    });
+  });
 };


### PR DESCRIPTION
`puts` from the ruby function are concatenated into a single log string, which means the monitoring outputs are not passed to DataDog in a way it can accurately consume. This PR modifies the wrapping JS to take output, split it into lines, and log each line separately, solving the problem.