### PR TITLE
Process each record individually

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,18 +1,21 @@
 const exec = require('child_process').exec;
 
 exports.handler = function(event, context) {
-  const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(event) + "' '" + JSON.stringify(context) + "'", (result) => {
-    context.done(result);
-  });
-
-  child.stdout.on('data', function (data) {
-    data.split("\n").forEach(function(x) {
-      console.log(x);
+  var context = context;
+  event['Records'].forEach(function(record) {
+    const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(record) + "' '" + JSON.stringify(context) + "'", (result) => {
+      context.done(result);
     });
-  });
-  child.stderr.on('data', function (data) {
-    data.split("\n").forEach(function(x) {
-      console.log(x);
+
+    child.stdout.on('data', function (data) {
+      data.split("\n").forEach(function(x) {
+        console.log(x);
+      });
+    });
+    child.stderr.on('data', function (data) {
+      data.split("\n").forEach(function(x) {
+        console.log(x);
+      });
     });
   });
 };


### PR DESCRIPTION
If we receive too many events at once, we can overload the max length of a command line argument to `./ruby_wrapper`. This solves the issue by invoking the ruby code once per event, rather than passing the entire JSON structure through.