### PR TITLE
Send 10 events to Ruby at a time

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,7 +1,7 @@
 const execFile = require('child_process').execFile;
 
 exports.handler = function(event, context) {
-  const chunkSize = 10;
+  const chunkSize = process.env.CHUNK_SIZE || 10;
 
   var records = event.Records;
   var context = context;

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,7 +1,7 @@
 const execFile = require('child_process').execFile;
 
 exports.handler = function(event, context) {
-  const chunkSize = 5;
+  const chunkSize = 10;
 
   var records = event.Records;
   var context = context;


### PR DESCRIPTION
Amplitude allows us to batch-send events to their API. They recommend no more than 10 at a time (https://amplitude.zendesk.com/hc/en-us/articles/204771828#upload-limit-free-plan), so that's what we're doing here. In conjuction with https://github.com/ezcater/api-lambdas/pull/26 this allows us to take advantage of that to send at most 10 events at a time to the Amplitude API.

Tested successfully on staging.