### PR TITLE
Write records to a temp file that can be read by Ruby

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,4 +1,5 @@
 const execFile = require('child_process').execFile;
+const fs = require("fs");
 
 exports.handler = function(event, context) {
   const chunkSize = process.env.CHUNK_SIZE || 10;
@@ -8,17 +9,13 @@ exports.handler = function(event, context) {
 
   console.log("Received " + records.length + " records.")
 
-  var chunkOffset = 0;
-  var chunks = []
+  var fileName = "/tmp/" + context.invokeid + ".json";
 
-  while (chunkOffset < records.length) {
-    chunks.push(records.slice(chunkOffset, chunkOffset + chunkSize));
-    chunkOffset += chunkSize;
-  }
+  fs.writeFile(fileName, JSON.stringify(records), (err) => {
+    if (err) throw err;
 
-  chunks.forEach(function(chunk, index) {
-    const child = execFile('./ruby_wrapper', [JSON.stringify(chunk), JSON.stringify(context)], {}, (error, stdout, stderr) => {
-      stdout.trim().split("\n").forEach(function(x) {
+    execFile('./ruby_wrapper', [fileName, JSON.stringify(context)], {}, (error, stdout, stderr) => {
+      stdout.trim().split("\n").forEach(function(x)
         log = x.trim();
         if (log !== "") {
           console.log(log);


### PR DESCRIPTION
If we try to pass too many records into the ruby wrapper on the command line, we get command line arg length errors. We resolved this by chunking the incoming data and processing in smaller batches. This wasn't as much of a big deal when we could only send one record per each API call.

But now that we can send batches in a single API call, it would be great to be able to process more records at a time, so here we're writing the records to a temp file, and then passing the file name in to the ruby wrapper, which then reads from that file and processes as before (in a different PR)