### PR TITLE
Moves SKIP_SEND check up to JS layer

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -9,28 +9,32 @@ exports.handler = function(event, context) {
 
   console.log("Received " + records.length + " records.")
 
-  var fileName = "/tmp/" + context.invokeid + ".json";
+  if (process.env.SKIP_SEND === "true") {
+    console.log(`SKIPPING SEND, received event data: ${JSON.stringify(records)}`);
+  } else {
+    var fileName = "/tmp/" + context.invokeid + ".json";
 
-  fs.writeFile(fileName, JSON.stringify(records), (err) => {
-    if (err) throw err;
+    fs.writeFile(fileName, JSON.stringify(records), (err) => {
+      if (err) throw err;
 
-    execFile('./ruby_wrapper', [fileName, JSON.stringify(context)], {}, (error, stdout, stderr) => {
-      stdout.trim().split("\n").forEach(function(x) {
-        log = x.trim();
-        if (log !== "") {
-          console.log(log);
+      execFile('./ruby_wrapper', [fileName, JSON.stringify(context)], {}, (error, stdout, stderr) => {
+        stdout.trim().split("\n").forEach(function(x) {
+          log = x.trim();
+          if (log !== "") {
+            console.log(log);
+          }
+        });
+        stderr.trim().split("\n").forEach(function(x) {
+          log = x.trim();
+          if (log !== "") {
+            console.log(log);
+          }
+        });
+        if (error) {
+          console.error(`exec error: ${error}`);
+          process.exit(1);
         }
       });
-      stderr.trim().split("\n").forEach(function(x) {
-        log = x.trim();
-        if (log !== "") {
-          console.log(log);
-        }
-      });
-      if (error) {
-        console.error(`exec error: ${error}`);
-        process.exit(1);
-      }
     });
-  });
+  }
 };


### PR DESCRIPTION
Avoids firing up a Ruby subprocess just to check an environment variable and exit.

Testing in a dev container, this reduces the total execution time to 10-25ms. Prod will likely be slower, but still way faster than before.

The diff shows a lot of churn, but really it's just the addition of the `if` block on lines 12-15 plus the close brace on 39 and reindentation.