### PR TITLE
Remove unused CHUNK_SIZE config

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -2,8 +2,6 @@ const execFile = require('child_process').execFile;
 const fs = require("fs");
 
 exports.handler = function(event, context) {
-  const chunkSize = process.env.CHUNK_SIZE || 10;
-
   var records = event.Records;
   var context = context;
 


### PR DESCRIPTION
We previously stoppped chunking events to Rumbda in 4d87506befd11dd11adbcd86264eb27e374c92bf