### PR TITLE
Adds env-var-enabled debug logging

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -5,17 +5,14 @@ exports.handler = function(event, context) {
   var records = event.Records;
   var context = context;
 
-  console.log("Received " + records.length + " records.")
+  var verb = process.env.SKIP_SEND === "true" ? "SKIPPING " : "Received ";
+  console.log(verb + records.length + " records.")
 
   if (process.env.DEBUG_LOGGING === "true") {
-    console.log(`Received event data: ${JSON.stringify(records)}`);
+    console.log(`DEBUG: Received event data: ${JSON.stringify(records)}`);
   }
 
-  if (process.env.SKIP_SEND === "true") {
-    if (process.env.DEBUG_LOGGING === "true") {
-      console.log(`SKIPPING SEND`);
-    }
-  } else {
+  if (process.env.SKIP_SEND !== "true") {
     var fileName = "/tmp/" + context.invokeid + ".json";
 
     fs.writeFile(fileName, JSON.stringify(records), (err) => {

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -7,8 +7,14 @@ exports.handler = function(event, context) {
 
   console.log("Received " + records.length + " records.")
 
+  if (process.env.DEBUG_LOGGING === "true") {
+    console.log(`Received event data: ${JSON.stringify(records)}`);
+  }
+
   if (process.env.SKIP_SEND === "true") {
-    console.log(`SKIPPING SEND, received event data: ${JSON.stringify(records)}`);
+    if (process.env.DEBUG_LOGGING === "true") {
+      console.log(`SKIPPING SEND`);
+    }
   } else {
     var fileName = "/tmp/" + context.invokeid + ".json";
 


### PR DESCRIPTION
Open to suggestions about what to log here. Seemed reasonable enough just to log the entirety of the events.

Pairs with https://github.com/ezcater/api-lambdas/pull/57.